### PR TITLE
Remove dependency between indentation rules by handling depth in TreeElement nodes

### DIFF
--- a/src/analysis/parsing/expression.rs
+++ b/src/analysis/parsing/expression.rs
@@ -38,7 +38,7 @@ impl TreeElement for UnaryExpressionContent {
     fn subs(&self) -> TreeElements<'_> {
         create_subs!(&self.operation, &self.expr)
     }
-    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: &mut AuxParams) {
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: AuxParams) {
         rules.nsp_unary.check(acc, NspUnaryArgs::from_unary_expr(self));
     }
 }
@@ -72,7 +72,7 @@ impl TreeElement for PostUnaryExpressionContent {
     fn subs(&self) -> TreeElements<'_> {
         create_subs!(&self.expr, &self.operation)
     }
-    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: &mut AuxParams) {
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: AuxParams) {
         rules.nsp_unary.check(acc, NspUnaryArgs::from_postunary_expr(self));
     }
 }
@@ -210,7 +210,7 @@ impl TreeElement for FunctionCallContent {
                 noderef, ReferenceKind::Callable));
         }
     }
-    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: &mut AuxParams) {
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: AuxParams) {
         rules.nsp_funpar.check(acc, NspFunparArgs::from_function_call(self));
         rules.nsp_inparen.check(acc, NspInparenArgs::from_function_call(self));
         rules.sp_punct.check(acc, SpPunctArgs::from_function_call(self));
@@ -421,7 +421,7 @@ impl TreeElement for IndexContent {
     fn subs(&self) -> TreeElements<'_> {
         create_subs!(&self.array, &self.lbracket, &self.index, &self.rbracket)
     }
-    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: &mut AuxParams) {
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: AuxParams) {
         rules.nsp_inparen.check(acc, NspInparenArgs::from_index(self));
     }
 }

--- a/src/analysis/parsing/statement.rs
+++ b/src/analysis/parsing/statement.rs
@@ -5,6 +5,7 @@ use log::error;
 use crate::lint::rules::indentation::IN10Args;
 use crate::span::Range;
 use crate::analysis::parsing::lexer::TokenKind;
+use crate::analysis::parsing::statement;
 use crate::analysis::parsing::parser::{Token, doesnt_understand_tokens,
                                        FileParser, Parse, ParseContext,
                                        FileInfo};
@@ -1016,6 +1017,21 @@ impl TreeElement for SwitchCase {
     }
     fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: AuxParams) {
         rules.in9.check(acc, IN9Args::from_switch_case(self, aux.depth));
+    }
+    fn should_increment_depth(&self) -> bool {
+        if let SwitchCase::Statement(statement) = self {
+            if let Content::Some(ref content) = *statement.content {
+                if let statement::StatementContent::Compound(_) = content {
+                    return false;
+                } else {
+                    return true;
+                }
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
     }
 }
 

--- a/src/analysis/parsing/statement.rs
+++ b/src/analysis/parsing/statement.rs
@@ -143,9 +143,12 @@ impl TreeElement for CompoundContent {
     fn subs(&self) -> TreeElements<'_> {
         create_subs!(&self.lbrace, &self.statements, &self.rbrace)
     }
-    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: &mut AuxParams) {
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: AuxParams) {
         rules.sp_brace.check(acc, SpBracesArgs::from_compound(self));
-        rules.in3.check(acc, IN3Args::from_compound_content(self, &mut aux.depth));
+        rules.in3.check(acc, IN3Args::from_compound_content(self, aux.depth));
+    }
+    fn should_increment_depth(&self) -> bool {
+        true
     }
 }
 
@@ -197,7 +200,7 @@ impl TreeElement for VariableDeclContent {
     fn post_parse_sanity(&self, _file: &TextFile) -> Vec<LocalDMLError> {
         self.decls.ensure_named()
     }
-    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: &mut AuxParams) {
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: AuxParams) {
         rules.sp_punct.check(acc, SpPunctArgs::from_variable_decl(self));
     }
 }
@@ -429,7 +432,7 @@ impl TreeElement for IfContent {
                      &self.truebranch,
                      &self.elsebranch)
     }
-    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: &mut AuxParams) {
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: AuxParams) {
         rules.nsp_inparen.check(acc, NspInparenArgs::from_if(self));
     }
 }
@@ -541,8 +544,8 @@ impl TreeElement for WhileContent {
                      &self.rparen,
                      &self.statement)
     }
-    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: &mut AuxParams) {
-        rules.in10.check(acc, IN10Args::from_while_content(self, &mut aux.depth));
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: AuxParams) {
+        rules.in10.check(acc, IN10Args::from_while_content(self, aux.depth));
     }
 }
 
@@ -852,8 +855,8 @@ impl TreeElement for ForContent {
                      &self.rparen,
                      &self.statement)
     }
-    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: &mut AuxParams) {
-        rules.in10.check(acc, IN10Args::from_for_content(self, &mut aux.depth));
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: AuxParams) {
+        rules.in10.check(acc, IN10Args::from_for_content(self, aux.depth));
     }
 }
 
@@ -1011,8 +1014,8 @@ impl TreeElement for SwitchCase {
             Self::Default(default, colon) => create_subs!(default, colon),
         }
     }
-    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: &mut AuxParams) {
-        rules.in9.check(acc, IN9Args::from_switch_case(self, &mut aux.depth));
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: AuxParams) {
+        rules.in9.check(acc, IN9Args::from_switch_case(self, aux.depth));
     }
 }
 
@@ -1723,7 +1726,7 @@ impl TreeElement for ExpressionStmtContent {
     fn subs(&self) -> TreeElements<'_> {
         create_subs!(&self.expression, &self.semi)
     }
-    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: &mut AuxParams) {
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: AuxParams) {
         rules.sp_punct.check(acc, SpPunctArgs::from_expression_stmt(self));
     }
 }

--- a/src/analysis/parsing/statement.rs
+++ b/src/analysis/parsing/statement.rs
@@ -1019,19 +1019,9 @@ impl TreeElement for SwitchCase {
         rules.in9.check(acc, IN9Args::from_switch_case(self, aux.depth));
     }
     fn should_increment_depth(&self) -> bool {
-        if let SwitchCase::Statement(statement) = self {
-            if let Content::Some(ref content) = *statement.content {
-                if let statement::StatementContent::Compound(_) = content {
-                    return false;
-                } else {
-                    return true;
-                }
-            } else {
-                return false;
-            }
-        } else {
-            return false;
-        }
+        matches!(self, SwitchCase::Statement(statement)
+            if !matches!(*statement.content,
+                Content::Some(statement::StatementContent::Compound(_))))
     }
 }
 

--- a/src/analysis/parsing/structure.rs
+++ b/src/analysis/parsing/structure.rs
@@ -235,7 +235,7 @@ impl TreeElement for MethodContent {
         }
         errors
     }
-    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: &mut AuxParams) {
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: AuxParams) {
         rules.nsp_funpar.check(acc, NspFunparArgs::from_method(self));
         rules.nsp_inparen.check(acc, NspInparenArgs::from_method(self));
         rules.sp_punct.check(acc, SpPunctArgs::from_method(self));
@@ -704,9 +704,9 @@ impl TreeElement for ObjectStatementsContent {
                 create_subs!(left, vect, right)
         }
     }
-    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: &mut AuxParams) {
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: AuxParams) {
         rules.sp_brace.check(acc, SpBracesArgs::from_obj_stmts(self));
-        rules.in3.check(acc, IN3Args::from_obj_stmts_content(self, &mut aux.depth));
+        rules.in3.check(acc, IN3Args::from_obj_stmts_content(self, aux.depth));
     }
 }
 
@@ -834,6 +834,9 @@ impl TreeElement for CompositeObjectContent {
         errors
     }
     fn references<'a>(&self, _accumulator: &mut Vec<Reference>, _file: FileSpec<'a>) {}
+    fn should_increment_depth(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/analysis/parsing/structure.rs
+++ b/src/analysis/parsing/structure.rs
@@ -10,7 +10,7 @@ use crate::analysis::parsing::misc::{CDecl, CDeclList, Initializer,
                                      ident_filter, objident_filter};
 use crate::analysis::parsing::statement::Statement;
 use crate::analysis::parsing::tree::{AstObject, TreeElement, TreeElements,
-                                     LeafToken, ZeroRange};
+                                     LeafToken, ZeroRange, Content};
 use crate::analysis::parsing::types::CTypeDecl;
 use crate::analysis::parsing::parser::{doesnt_understand_tokens,
                                        FileParser, Parse, ParseContext,
@@ -835,7 +835,13 @@ impl TreeElement for CompositeObjectContent {
     }
     fn references<'a>(&self, _accumulator: &mut Vec<Reference>, _file: FileSpec<'a>) {}
     fn should_increment_depth(&self) -> bool {
-        true
+        match &*self.statements.content {
+            Content::Some(ObjectStatementsContent::List(lbrace, list, rbrace)) => {
+                ! (lbrace.range().row_start == list.range().row_start ||
+                    lbrace.range().row_start == rbrace.range().row_end)
+            },
+            _ => true,
+        }
     }
 }
 

--- a/src/analysis/parsing/tree.rs
+++ b/src/analysis/parsing/tree.rs
@@ -92,12 +92,6 @@ pub trait TreeElement {
     }
 
     fn style_check(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, mut aux: AuxParams) {
-        /* 
-        method my_method(int a, int b) {
-            if (1) { // Depth ++
-                return true; // Depth ++
-            }
-        } */
         if self.should_increment_depth() {
             aux.depth += 1;
         }

--- a/src/analysis/parsing/tree.rs
+++ b/src/analysis/parsing/tree.rs
@@ -100,8 +100,6 @@ pub trait TreeElement {
         } */
         if self.should_increment_depth() {
             aux.depth += 1;
-            print!("\nIncrementing depth! {} For\n {},{}", aux.depth,
-                   self.range().row_start.0, self.range().col_start.0);
         }
         self.evaluate_rules(acc, rules, aux);
         for sub in self.subs() {

--- a/src/analysis/parsing/types.rs
+++ b/src/analysis/parsing/types.rs
@@ -53,8 +53,8 @@ impl TreeElement for StructTypeContent {
         }
         errors
     }
-    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: &mut AuxParams) {
-        rules.in3.check(acc, IN3Args::from_struct_type_content(self, &mut aux.depth));
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: AuxParams) {
+        rules.in3.check(acc, IN3Args::from_struct_type_content(self, aux.depth));
         rules.sp_brace.check(acc, SpBracesArgs::from_struct_type_content(self));
     }
 }
@@ -132,8 +132,8 @@ impl TreeElement for LayoutContent {
         }
         errors
     }
-    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: &mut AuxParams) {
-        rules.in3.check(acc, IN3Args::from_layout_content(self, &mut aux.depth));
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: AuxParams) {
+        rules.in3.check(acc, IN3Args::from_layout_content(self, aux.depth));
         rules.sp_brace.check(acc, SpBracesArgs::from_layout_content(self));
     }
 }
@@ -305,7 +305,7 @@ impl TreeElement for BitfieldsContent {
         }
         errors
     }
-    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: &mut AuxParams) {
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: AuxParams) {
         rules.sp_brace.check(acc, SpBracesArgs::from_bitfields_content(self));
     }
 }

--- a/src/analysis/parsing/types.rs
+++ b/src/analysis/parsing/types.rs
@@ -57,6 +57,9 @@ impl TreeElement for StructTypeContent {
         rules.in3.check(acc, IN3Args::from_struct_type_content(self, aux.depth));
         rules.sp_brace.check(acc, SpBracesArgs::from_struct_type_content(self));
     }
+    fn should_increment_depth(&self) -> bool {
+        true
+    }
 }
 
 impl Parse<BaseTypeContent> for StructTypeContent {
@@ -135,6 +138,9 @@ impl TreeElement for LayoutContent {
     fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: AuxParams) {
         rules.in3.check(acc, IN3Args::from_layout_content(self, aux.depth));
         rules.sp_brace.check(acc, SpBracesArgs::from_layout_content(self));
+    }
+    fn should_increment_depth(&self) -> bool {
+        true
     }
 }
 
@@ -305,8 +311,12 @@ impl TreeElement for BitfieldsContent {
         }
         errors
     }
-    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: AuxParams) {
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: AuxParams) {
         rules.sp_brace.check(acc, SpBracesArgs::from_bitfields_content(self));
+        rules.in3.check(acc, IN3Args::from_bitfields_content(self, aux.depth));
+    }
+    fn should_increment_depth(&self) -> bool {
+        true
     }
 }
 

--- a/src/lint/rules/indentation.rs
+++ b/src/lint/rules/indentation.rs
@@ -449,7 +449,7 @@ impl IN10Args {
             return Some(IN10Args {
                 loop_keyword_range: node.fortok.range(),
                 semicolon_range: semicolon.range(),
-                expected_depth: depth
+                expected_depth: depth + 1
             });
             
         }
@@ -461,7 +461,7 @@ impl IN10Args {
             return Some(IN10Args {
                 loop_keyword_range: node.whiletok.range(),
                 semicolon_range: semicolon.range(),
-                expected_depth: depth
+                expected_depth: depth + 1
             });
             
         }

--- a/src/lint/rules/indentation.rs
+++ b/src/lint/rules/indentation.rs
@@ -144,15 +144,15 @@ pub struct IN3Options {
     pub indentation_spaces: u32,
 }
 
-pub struct IN3Args<'a> {
+pub struct IN3Args {
     members_ranges: Vec<ZeroRange>,
     lbrace: ZeroRange,
     rbrace: ZeroRange,
-    expected_depth: &'a mut u32,
+    expected_depth: u32,
 }
 
-impl IN3Args<'_> {
-    pub fn from_obj_stmts_content<'a>(node: &ObjectStatementsContent, depth: &'a mut u32) -> Option<IN3Args<'a>> {
+impl IN3Args {
+    pub fn from_obj_stmts_content(node: &ObjectStatementsContent, depth: u32) -> Option<IN3Args> {
         if let ObjectStatementsContent::List(lbrace, stmnts, rbrace) = node {
             Some(IN3Args {
                 members_ranges: stmnts.iter().map(|s| s.range()).collect(),
@@ -164,7 +164,7 @@ impl IN3Args<'_> {
             None
         }
     }
-    pub fn from_struct_type_content<'a>(node: &StructTypeContent, depth: &'a mut u32) -> Option<IN3Args<'a>> {
+    pub fn from_struct_type_content(node: &StructTypeContent, depth: u32) -> Option<IN3Args> {
         Some(IN3Args {
             members_ranges: node.members.iter().map(|m| m.range()).collect(),
             lbrace: node.lbrace.range(),
@@ -172,7 +172,7 @@ impl IN3Args<'_> {
             expected_depth: depth,
         })
     }
-    pub fn from_compound_content<'a>(node: &CompoundContent, depth: &'a mut u32) -> Option<IN3Args<'a>> {
+    pub fn from_compound_content(node: &CompoundContent, depth: u32) -> Option<IN3Args> {
         Some(IN3Args {
             members_ranges: node.statements.iter().map(|s| s.range()).collect(),
             lbrace: node.lbrace.range(),
@@ -180,7 +180,7 @@ impl IN3Args<'_> {
             expected_depth: depth,
         })
     }
-    pub fn from_layout_content<'a>(node: &LayoutContent, depth: &'a mut u32) -> Option<IN3Args<'a>> {
+    pub fn from_layout_content(node: &LayoutContent, depth: u32) -> Option<IN3Args> {
         Some(IN3Args {
             members_ranges: node.fields.iter().map(|m| m.range()).collect(),
             lbrace: node.lbrace.range(),
@@ -203,16 +203,15 @@ impl IN3Rule {
             }
         }
     }
-    pub fn check<'a>(&self, acc: &mut Vec<DMLStyleError>,
-        args: Option<IN3Args<'a>>)
+    pub fn check(&self, acc: &mut Vec<DMLStyleError>,
+        args: Option<IN3Args>)
     {
         if !self.enabled { return; }
         let Some(args) = args else { return; };
         if args.lbrace.row_start == args.rbrace.row_start ||
             args.lbrace.row_start == args.members_ranges[0].row_start { return; }
-        *args.expected_depth += 1;
         for member_range in args.members_ranges {
-            if self.indentation_is_not_aligned(member_range, *args.expected_depth) {
+            if self.indentation_is_not_aligned(member_range, args.expected_depth) {
                 let dmlerror = DMLStyleError {
                     error: LocalDMLError {
                         range: member_range,
@@ -227,7 +226,12 @@ impl IN3Rule {
     fn indentation_is_not_aligned(&self, member_range: ZeroRange, depth: u32) -> bool {
         // Implicit IN1
         let expected_column = self.indentation_spaces * depth;
-        member_range.col_start.0 != expected_column
+        let res = member_range.col_start.0 != expected_column;
+        if res {
+            print!("\nFailed at row {}! {} vs {}",member_range.row_start.0, member_range.col_start.0, expected_column);
+        }
+        res
+
     }
 }
 
@@ -341,13 +345,13 @@ pub struct IN9Options {
     pub indentation_spaces: u32,
 }
 
-pub struct IN9Args<'a> {
+pub struct IN9Args {
     case_range: ZeroRange,
-    expected_depth: &'a mut u32,
+    expected_depth: u32,
 }
 
-impl IN9Args<'_> {
-    pub fn from_switch_case<'a>(node: &SwitchCase, depth: &'a mut u32) -> Option<IN9Args<'a>> {
+impl IN9Args {
+    pub fn from_switch_case(node: &SwitchCase, depth: u32) -> Option<IN9Args> {
         match node {
             SwitchCase::Case(_, _, _) |
             SwitchCase::Default(_, _) => {},
@@ -356,7 +360,6 @@ impl IN9Args<'_> {
                     if let statement::StatementContent::Compound(_) = content {
                         return None;
                     }
-                    *depth += 1;
                 }
             },
             SwitchCase::HashIf(_) => {
@@ -385,12 +388,12 @@ impl IN9Rule {
             }
         }
     }
-    pub fn check<'a>(&self, acc: &mut Vec<DMLStyleError>,
-        args: Option<IN9Args<'a>>)
+    pub fn check(&self, acc: &mut Vec<DMLStyleError>,
+        args: Option<IN9Args>)
     {
         if !self.enabled { return; }
         let Some(args) = args else { return; };
-        if self.indentation_is_not_aligned(args.case_range, *args.expected_depth) {
+        if self.indentation_is_not_aligned(args.case_range, args.expected_depth) {
             let dmlerror = DMLStyleError {
                 error: LocalDMLError {
                     range: args.case_range,
@@ -434,16 +437,15 @@ pub struct IN10Options {
     pub indentation_spaces: u32,
 }
 
-pub struct IN10Args<'a> {
+pub struct IN10Args {
     loop_keyword_range: ZeroRange,
     semicolon_range: ZeroRange,
-    expected_depth: &'a mut u32,
+    expected_depth: u32,
 }
 
-impl IN10Args<'_> {
-    pub fn from_for_content<'a>(node: &ForContent, depth: &'a mut u32) -> Option<IN10Args<'a>> {
+impl IN10Args {
+    pub fn from_for_content(node: &ForContent, depth: u32) -> Option<IN10Args> {
         if let Content::Some(statement::StatementContent::Empty(semicolon)) = node.statement.content.as_ref() {
-            *depth += 1;
             return Some(IN10Args {
                 loop_keyword_range: node.fortok.range(),
                 semicolon_range: semicolon.range(),
@@ -454,9 +456,8 @@ impl IN10Args<'_> {
         return None;
     }
 
-    pub fn from_while_content<'a>(node: &WhileContent, depth: &'a mut u32) -> Option<IN10Args<'a>> {
+    pub fn from_while_content(node: &WhileContent, depth: u32) -> Option<IN10Args> {
         if let Content::Some(statement::StatementContent::Empty(semicolon)) = node.statement.content.as_ref() {
-            *depth += 1;
             return Some(IN10Args {
                 loop_keyword_range: node.whiletok.range(),
                 semicolon_range: semicolon.range(),
@@ -481,12 +482,12 @@ impl IN10Rule {
             }
         }
     }
-    pub fn check<'a>(&self, acc: &mut Vec<DMLStyleError>,
-        args: Option<IN10Args<'a>>)
+    pub fn check(&self, acc: &mut Vec<DMLStyleError>,
+        args: Option<IN10Args>)
     {
         if !self.enabled { return; }
         let Some(args) = args else { return; };
-        if self.indentation_is_not_aligned(args.semicolon_range, *args.expected_depth) ||
+        if self.indentation_is_not_aligned(args.semicolon_range, args.expected_depth) ||
             args.loop_keyword_range.row_start == args.semicolon_range.row_start {
             let dmlerror = DMLStyleError {
                 error: LocalDMLError {

--- a/src/lint/rules/indentation.rs
+++ b/src/lint/rules/indentation.rs
@@ -226,12 +226,7 @@ impl IN3Rule {
     fn indentation_is_not_aligned(&self, member_range: ZeroRange, depth: u32) -> bool {
         // Implicit IN1
         let expected_column = self.indentation_spaces * depth;
-        let res = member_range.col_start.0 != expected_column;
-        if res {
-            print!("\nFailed at row {}! {} vs {}",member_range.row_start.0, member_range.col_start.0, expected_column);
-        }
-        res
-
+        member_range.col_start.0 != expected_column
     }
 }
 

--- a/src/lint/rules/indentation.rs
+++ b/src/lint/rules/indentation.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 use crate::analysis::parsing::{statement::{self, CompoundContent, ForContent,
                                SwitchCase, WhileContent},
                                structure::ObjectStatementsContent,
-                               types::{LayoutContent, StructTypeContent}};
+                               types::{BitfieldsContent, LayoutContent, StructTypeContent}};
 use crate::span::{Range, ZeroIndexed, Row, Column};
 use crate::analysis::LocalDMLError;
 use crate::analysis::parsing::tree::{ZeroRange, Content, TreeElement};
@@ -181,6 +181,14 @@ impl IN3Args {
         })
     }
     pub fn from_layout_content(node: &LayoutContent, depth: u32) -> Option<IN3Args> {
+        Some(IN3Args {
+            members_ranges: node.fields.iter().map(|m| m.range()).collect(),
+            lbrace: node.lbrace.range(),
+            rbrace: node.rbrace.range(),
+            expected_depth: depth,
+        })
+    }
+    pub fn from_bitfields_content(node: &BitfieldsContent, depth: u32) -> Option<IN3Args> {
         Some(IN3Args {
             members_ranges: node.fields.iter().map(|m| m.range()).collect(),
             lbrace: node.lbrace.range(),

--- a/src/lint/rules/tests/common.rs
+++ b/src/lint/rules/tests/common.rs
@@ -9,7 +9,7 @@ pub fn run_linter(source_code: &str, rules: &CurrentRules)
 {
     print!("\nSnippet to test on:\n{}\n", source_code);
     let ast = create_ast_from_snippet(source_code);
-    print!("Resulting AST:\n{:#?}\n", ast);
+    // print!("Resulting AST:\n{:#?}\n", ast);
     begin_style_check(ast, source_code.to_string(), rules)
 }
 

--- a/src/lint/rules/tests/common.rs
+++ b/src/lint/rules/tests/common.rs
@@ -9,7 +9,7 @@ pub fn run_linter(source_code: &str, rules: &CurrentRules)
 {
     print!("\nSnippet to test on:\n{}\n", source_code);
     let ast = create_ast_from_snippet(source_code);
-    // print!("Resulting AST:\n{:#?}\n", ast);
+    print!("Resulting AST:\n{:#?}\n", ast);
     begin_style_check(ast, source_code.to_string(), rules)
 }
 

--- a/src/lint/rules/tests/indentation/in10.rs
+++ b/src/lint/rules/tests/indentation/in10.rs
@@ -58,14 +58,43 @@ method some_function() {
 ";
 
 #[test]
-fn in10_empty_loop() {
+fn test_empty_loop_incorrect() {
     let rules = set_up();
-
     assert_snippet(IN10_EMPTY_LOOP_INCORRECT, 1, &rules);
+}
+
+#[test]
+fn test_empty_loop_incorrect_2() {
+    let rules = set_up();
     assert_snippet(IN10_EMPTY_LOOP_INCORRECT_2, 1, &rules);
+}
+
+#[test]
+fn test_empty_loop_incorrect_3() {
+    let rules = set_up();
     assert_snippet(IN10_EMPTY_LOOP_INCORRECT_3, 1, &rules);
+}
+
+#[test]
+fn test_empty_loop_ok() {
+    let rules = set_up();
     assert_snippet(IN10_EMPTY_LOOP_OK, 0, &rules);
+}
+
+#[test]
+fn test_empty_loop_ok_2() {
+    let rules = set_up();
     assert_snippet(IN10_EMPTY_LOOP_OK_2, 0, &rules);
+}
+
+#[test]
+fn test_nested_loop_incorrect() {
+    let rules = set_up();
     assert_snippet(IN10_NESTED_LOOP_INCORRECT, 1, &rules);
+}
+
+#[test]
+fn test_nested_loop_ok() {
+    let rules = set_up();
     assert_snippet(IN10_NESTED_LOOP_OK, 0, &rules);
 }

--- a/src/lint/rules/tests/indentation/in3.rs
+++ b/src/lint/rules/tests/indentation/in3.rs
@@ -100,14 +100,15 @@ fn in3_full_bank_correct_indent() {
     assert_indentation(IN3_FULL_BANK_CORRECT_INDENT, 0, rules);
 }
 
-pub static IN3_STRUCTS_BAD_INDENT: &str = "
+pub static IN3_STRUCTS_CORRECT_INDENT: &str = "
 typedef struct {
-     uint16 idx;
-       uint16 qid_co;
-} hqm_cq_list_release_ctx_t;
+    uint16 idx;
+    uint8 qid_co;
+    uint8 pid;
+} cq_list_release_ctx_t;
 
 typedef layout \"little-endian\" {
-     bitfields 8 {
+    bitfields 8 {
         uint2 rsvd             @ [7:6];
         uint1 error_f          @ [5:5];
         uint1 int_arm          @ [4:4];
@@ -119,9 +120,34 @@ typedef layout \"little-endian\" {
 } prod_qe_cmd_t;
 ";
 #[test]
+fn in3_structs_correct_indent() {
+    let rules = set_up();
+    assert_indentation(IN3_STRUCTS_CORRECT_INDENT, 0, rules);
+}
+
+pub static IN3_STRUCTS_BAD_INDENT: &str = "
+typedef struct {
+     uint16 idx;
+       uint8 qid_co;
+    uint8 pid;
+} cq_list_release_ctx_t;
+
+typedef layout \"little-endian\" {
+     bitfields 8 {
+        uint2 rsvd             @ [7:6];
+        uint1 error_f          @ [5:5];
+          uint1 int_arm        @ [4:4];
+          uint1 qe_valid       @ [3:3];
+        uint1 qe_frag          @ [2:2];
+        uint1 qe_comp          @ [1:1];
+        uint1 cq_token         @ [0:0];
+    } byte;
+} prod_qe_cmd_t;
+";
+#[test]
 fn in3_structs_bad_indent() {
     let rules = set_up();
-    assert_indentation(IN3_STRUCTS_BAD_INDENT, 3, rules);
+    assert_indentation(IN3_STRUCTS_BAD_INDENT, 5, rules);
 }
 
 pub static IN3_COND_STRUCTURE_BAD_INDENT: &str = "
@@ -142,4 +168,48 @@ method control_device() {
 fn in3_cond_structure_bad_indent() {
     let rules = set_up();
     assert_indentation(IN3_COND_STRUCTURE_BAD_INDENT, 4, rules);
+}
+
+pub static IN3_EMBEDDED_CORRECT_INDENT: &str = "
+bank pcie_config {
+    register command {
+        field mem {
+            method pcie_write(uint64 value) {
+                if (value != 0) {
+                    value = value + 1;
+                    callback();
+                }
+                default(value);
+                map_memory_alt();
+            }
+        }
+    }
+}
+";
+#[test]
+fn in3_embedded_correct_indent() {
+    let rules = set_up();
+    assert_indentation(IN3_EMBEDDED_CORRECT_INDENT, 0, rules);
+}
+
+pub static IN3_EMBEDDED_INCORRECT_INDENT: &str = "
+bank pcie_config {
+    register command {
+          field mem {
+            method pcie_write(uint64 value) {
+                if (value != 0) {
+                value = value + 1;
+                    callback();
+                }
+              default(value);
+                map_memory_alt();
+            }
+        }
+    }
+}
+";
+#[test]
+fn in3_embedded_incorrect_indent() {
+    let rules = set_up();
+    assert_indentation(IN3_EMBEDDED_INCORRECT_INDENT, 3, rules);
 }


### PR DESCRIPTION
Expected depth can now be calculated based solely on the AST and does not depend on the application or enabling of any particular rule.