### PR TITLE
Add sp_binop and sp_ternary rules to lint module checks

### DIFF
--- a/example_files/example_lint_cfg.json
+++ b/example_files/example_lint_cfg.json
@@ -1,6 +1,7 @@
 {
     "sp_brace": {},
     "sp_punct": {},
+    "sp_binop": {},
     "nsp_funpar": {},
     "nsp_inparen": {},
     "nsp_unary": {},

--- a/example_files/example_lint_cfg.json
+++ b/example_files/example_lint_cfg.json
@@ -2,6 +2,7 @@
     "sp_brace": {},
     "sp_punct": {},
     "sp_binop": {},
+    "sp_ternary" : {},
     "nsp_funpar": {},
     "nsp_inparen": {},
     "nsp_unary": {},

--- a/src/analysis/parsing/expression.rs
+++ b/src/analysis/parsing/expression.rs
@@ -22,6 +22,7 @@ use crate::lint::{DMLStyleError,
                                     NspInparenArgs,
                                     NspUnaryArgs,
                                     SpBinopArgs,
+                                    SpTernaryArgs,
                                     SpPunctArgs},
                                     CurrentRules},
                                     AuxParams};
@@ -154,6 +155,9 @@ impl TreeElement for TertiaryExpressionContent {
     fn subs(&self) -> TreeElements<'_> {
         create_subs!(&self.left, &self.left_operation,
                      &self.middle, &self.right_operation, &self.right)
+    }
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: AuxParams) {
+        rules.sp_ternary.check(acc, SpTernaryArgs::from_tertiary_expression_content(self));
     }
 }
 

--- a/src/analysis/parsing/expression.rs
+++ b/src/analysis/parsing/expression.rs
@@ -21,6 +21,7 @@ use crate::lint::{DMLStyleError,
                   rules::{spacing::{NspFunparArgs,
                                     NspInparenArgs,
                                     NspUnaryArgs,
+                                    SpBinopArgs,
                                     SpPunctArgs},
                                     CurrentRules},
                                     AuxParams};
@@ -91,6 +92,9 @@ impl TreeElement for BinaryExpressionContent {
     }
     fn subs(&self) -> TreeElements<'_> {
         create_subs!(&self.left, &self.operation, &self.right)
+    }
+    fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, _aux: AuxParams) {
+        rules.sp_binop.check(acc, SpBinopArgs::from_binary_expression_content(self));
     }
 }
 

--- a/src/lint/features.md
+++ b/src/lint/features.md
@@ -3,6 +3,7 @@
 Below are listed the currently supported rules for linting:
 
 ## Spacing
+- SpBinop, `sp_binop`: spaces around binary operators except for derefencing operators (dot `a.b` and arrow `a->b` )
 - SpBraces, `sp_brace`: spaces around braces (`{` and `}`)
 - SpPunct, `sp_punct`: spaces after but not before colon, semicolon and comma
 - NspFunpar, `nsp_funpar`: no spaces between a function/method name and its opening parenthesis

--- a/src/lint/features.md
+++ b/src/lint/features.md
@@ -4,6 +4,7 @@ Below are listed the currently supported rules for linting:
 
 ## Spacing
 - SpBinop, `sp_binop`: spaces around binary operators except for derefencing operators (dot `a.b` and arrow `a->b` )
+- SpTernary, `sp_ternary`: spaces around `?` and `:` in ternary conditional expressions
 - SpBraces, `sp_brace`: spaces around braces (`{` and `}`)
 - SpPunct, `sp_punct`: spaces after but not before colon, semicolon and comma
 - NspFunpar, `nsp_funpar`: no spaces between a function/method name and its opening parenthesis

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
 use log::{debug, error, trace};
+use rules::spacing::SpTernaryOptions;
 use serde::{Deserialize, Serialize};
 use rules::{instantiate_rules, CurrentRules, RuleType};
 use rules::{spacing::{SpBraceOptions, SpPunctOptions, SpBinopOptions, NspFunparOptions,
@@ -52,6 +53,8 @@ pub struct LintCfg {
     #[serde(default)]
     pub sp_binop: Option<SpBinopOptions>,
     #[serde(default)]
+    pub sp_ternary: Option<SpTernaryOptions>,
+    #[serde(default)]
     pub nsp_funpar: Option<NspFunparOptions>,
     #[serde(default)]
     pub nsp_inparen: Option<NspInparenOptions>,
@@ -83,6 +86,7 @@ impl Default for LintCfg {
             sp_brace: Some(SpBraceOptions{}),
             sp_punct: Some(SpPunctOptions{}),
             sp_binop: Some(SpBinopOptions{}),
+            sp_ternary: Some(SpTernaryOptions{}),
             nsp_funpar: Some(NspFunparOptions{}),
             nsp_inparen: Some(NspInparenOptions{}),
             nsp_unary: Some(NspUnaryOptions{}),

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use log::{debug, error, trace};
 use serde::{Deserialize, Serialize};
 use rules::{instantiate_rules, CurrentRules, RuleType};
-use rules::{spacing::{SpBraceOptions, SpPunctOptions, NspFunparOptions,
+use rules::{spacing::{SpBraceOptions, SpPunctOptions, SpBinopOptions, NspFunparOptions,
                       NspInparenOptions, NspUnaryOptions, NspTrailingOptions},
                       indentation::{LongLineOptions, IndentSizeOptions, IndentCodeBlockOptions,
                                     IndentNoTabOptions, IndentClosingBraceOptions, IndentParenExprOptions, IndentSwitchCaseOptions, IndentEmptyLoopOptions},
@@ -50,6 +50,8 @@ pub struct LintCfg {
     #[serde(default)]
     pub sp_punct: Option<SpPunctOptions>,
     #[serde(default)]
+    pub sp_binop: Option<SpBinopOptions>,
+    #[serde(default)]
     pub nsp_funpar: Option<NspFunparOptions>,
     #[serde(default)]
     pub nsp_inparen: Option<NspInparenOptions>,
@@ -80,6 +82,7 @@ impl Default for LintCfg {
         LintCfg {
             sp_brace: Some(SpBraceOptions{}),
             sp_punct: Some(SpPunctOptions{}),
+            sp_binop: Some(SpBinopOptions{}),
             nsp_funpar: Some(NspFunparOptions{}),
             nsp_inparen: Some(NspInparenOptions{}),
             nsp_unary: Some(NspUnaryOptions{}),

--- a/src/lint/rules/mod.rs
+++ b/src/lint/rules/mod.rs
@@ -4,9 +4,7 @@ pub mod indentation;
 #[cfg(test)]
 pub mod tests;
 
-use spacing::{SpBracesRule, SpBinopRule,
-    SpPunctRule, NspFunparRule, NspInparenRule,
-    NspUnaryRule, NspTrailingRule};
+use spacing::{NspFunparRule, NspInparenRule, NspTrailingRule, NspUnaryRule, SpBinopRule, SpBracesRule, SpPunctRule, SpTernaryRule};
 use indentation::{LongLinesRule, IndentNoTabRule, IndentCodeBlockRule, IndentClosingBraceRule, IndentParenExprRule, IndentSwitchCaseRule, IndentEmptyLoopRule};
 use crate::lint::{LintCfg, DMLStyleError};
 use crate::analysis::{LocalDMLError, parsing::tree::ZeroRange};
@@ -15,6 +13,7 @@ pub struct CurrentRules {
     pub sp_brace: SpBracesRule,
     pub sp_punct: SpPunctRule,
     pub sp_binop: SpBinopRule,
+    pub sp_ternary: SpTernaryRule,
     pub nsp_funpar: NspFunparRule,
     pub nsp_inparen: NspInparenRule,
     pub nsp_unary: NspUnaryRule,
@@ -33,6 +32,7 @@ pub fn  instantiate_rules(cfg: &LintCfg) -> CurrentRules {
         sp_brace: SpBracesRule { enabled: cfg.sp_brace.is_some() },
         sp_punct: SpPunctRule { enabled: cfg.sp_punct.is_some() },
         sp_binop: SpBinopRule { enabled: cfg.sp_binop.is_some() },
+        sp_ternary: SpTernaryRule { enabled: cfg.sp_ternary.is_some() },
         nsp_funpar: NspFunparRule { enabled: cfg.nsp_funpar.is_some() },
         nsp_inparen: NspInparenRule { enabled: cfg.nsp_inparen.is_some() },
         nsp_unary: NspUnaryRule { enabled: cfg.nsp_unary.is_some() },
@@ -68,6 +68,7 @@ pub enum RuleType {
     SpBraces,
     SpPunct,
     SpBinop,
+    SpTernary,
     NspFunpar,
     NspInparen,
     NspUnary,

--- a/src/lint/rules/mod.rs
+++ b/src/lint/rules/mod.rs
@@ -4,7 +4,7 @@ pub mod indentation;
 #[cfg(test)]
 pub mod tests;
 
-use spacing::{SpBracesRule,
+use spacing::{SpBracesRule, SpBinopRule,
     SpPunctRule, NspFunparRule, NspInparenRule,
     NspUnaryRule, NspTrailingRule};
 use indentation::{LongLinesRule, IndentNoTabRule, IndentCodeBlockRule, IndentClosingBraceRule, IndentParenExprRule, IndentSwitchCaseRule, IndentEmptyLoopRule};
@@ -14,6 +14,7 @@ use crate::analysis::{LocalDMLError, parsing::tree::ZeroRange};
 pub struct CurrentRules {
     pub sp_brace: SpBracesRule,
     pub sp_punct: SpPunctRule,
+    pub sp_binop: SpBinopRule,
     pub nsp_funpar: NspFunparRule,
     pub nsp_inparen: NspInparenRule,
     pub nsp_unary: NspUnaryRule,
@@ -31,6 +32,7 @@ pub fn  instantiate_rules(cfg: &LintCfg) -> CurrentRules {
     CurrentRules {
         sp_brace: SpBracesRule { enabled: cfg.sp_brace.is_some() },
         sp_punct: SpPunctRule { enabled: cfg.sp_punct.is_some() },
+        sp_binop: SpBinopRule { enabled: cfg.sp_binop.is_some() },
         nsp_funpar: NspFunparRule { enabled: cfg.nsp_funpar.is_some() },
         nsp_inparen: NspInparenRule { enabled: cfg.nsp_inparen.is_some() },
         nsp_unary: NspUnaryRule { enabled: cfg.nsp_unary.is_some() },
@@ -65,6 +67,7 @@ pub trait Rule {
 pub enum RuleType {
     SpBraces,
     SpPunct,
+    SpBinop,
     NspFunpar,
     NspInparen,
     NspUnary,

--- a/src/lint/rules/spacing.rs
+++ b/src/lint/rules/spacing.rs
@@ -6,7 +6,8 @@ use crate::analysis::parsing::types::{BitfieldsContent, LayoutContent,
 use crate::lint::{rules::{Rule, RuleType},
                   DMLStyleError};
 use crate::analysis::parsing::tree::{TreeElement, ZeroRange};
-use crate::analysis::parsing::expression::{FunctionCallContent, IndexContent,
+use crate::analysis::parsing::expression::{BinaryExpressionContent,
+                                           FunctionCallContent, IndexContent,
                                            PostUnaryExpressionContent,
                                            UnaryExpressionContent};
 use crate::analysis::parsing::statement::{CompoundContent,
@@ -122,6 +123,54 @@ impl Rule for SpBracesRule {
     }
     fn get_rule_type() -> RuleType {
         RuleType::SpBraces
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct SpBinopOptions {}
+pub struct SpBinopRule {
+    pub enabled: bool,
+}
+pub struct SpBinopArgs {
+    left: ZeroRange,
+    operator:  ZeroRange,
+    right: ZeroRange,
+}
+impl SpBinopArgs {
+    pub fn from_binary_expression_content(node: &BinaryExpressionContent) -> Option<SpBinopArgs> {
+        Some(SpBinopArgs {
+            left: node.left.range(),
+            operator: node.operation.range(),
+            right: node.right.range(),
+        })
+    }
+}
+impl SpBinopRule {
+    pub fn check(&self, acc: &mut Vec<DMLStyleError>,
+        ranges: Option<SpBinopArgs>) {
+        if !self.enabled { return; }
+        if let Some(location) = ranges {
+            if (location.left.row_end == location.operator.row_start)
+                && (location.left.col_end == location.operator.col_start) {
+                acc.push(self.create_err(location.left));
+            }
+            if (location.right.row_start == location.operator.row_end)
+                && (location.operator.col_end == location.right.col_start) {
+
+                acc.push(self.create_err(location.right));
+            }
+        }
+    }
+}
+impl Rule for SpBinopRule {
+    fn name() -> &'static str {
+        "SP_BINOP"
+    }
+    fn description() -> &'static str {
+        "Missing space around binary operator"
+    }
+    fn get_rule_type() -> RuleType {
+        RuleType::SpBinop
     }
 }
 

--- a/src/lint/rules/spacing.rs
+++ b/src/lint/rules/spacing.rs
@@ -6,10 +6,7 @@ use crate::analysis::parsing::types::{BitfieldsContent, LayoutContent,
 use crate::lint::{rules::{Rule, RuleType},
                   DMLStyleError};
 use crate::analysis::parsing::tree::{TreeElement, ZeroRange};
-use crate::analysis::parsing::expression::{BinaryExpressionContent,
-                                           FunctionCallContent, IndexContent,
-                                           PostUnaryExpressionContent,
-                                           UnaryExpressionContent};
+use crate::analysis::parsing::expression::{BinaryExpressionContent, FunctionCallContent, IndexContent, PostUnaryExpressionContent, TertiaryExpressionContent, UnaryExpressionContent};
 use crate::analysis::parsing::statement::{CompoundContent,
                                           ExpressionStmtContent,
                                           IfContent, VariableDeclContent};
@@ -171,6 +168,66 @@ impl Rule for SpBinopRule {
     }
     fn get_rule_type() -> RuleType {
         RuleType::SpBinop
+    }
+}
+
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct SpTernaryOptions {}
+pub struct SpTernaryRule {
+    pub enabled: bool,
+}
+pub struct SpTernaryArgs {
+    left: ZeroRange,
+    left_op: ZeroRange,
+    middle: ZeroRange,
+    right_op: ZeroRange,
+    right: ZeroRange,
+}
+impl SpTernaryArgs {
+    pub fn from_tertiary_expression_content(node: &TertiaryExpressionContent) -> Option<SpTernaryArgs> {
+        Some(SpTernaryArgs {
+            left: node.left.range(),
+            left_op: node.left_operation.range(),
+            middle: node.middle.range(),
+            right_op: node.right_operation.range(),
+            right: node.right.range(),
+        })
+    }
+}
+fn no_gap(left: ZeroRange, right: ZeroRange) -> bool {
+    left.row_end == right.row_start
+        && left.col_end == right.col_start
+}
+impl SpTernaryRule {
+    pub fn check(&self, acc: &mut Vec<DMLStyleError>,
+        ranges: Option<SpTernaryArgs>) {
+        if !self.enabled { return; }
+        if let Some(SpTernaryArgs { left, left_op, middle, right_op, right }) = ranges {
+            if no_gap(left, left_op) {
+                acc.push(self.create_err(left));
+            }
+            if no_gap(left_op, middle) {
+                acc.push(self.create_err(middle));
+            }
+            if no_gap(middle, right_op) {
+                acc.push(self.create_err(middle));
+            }
+            if no_gap(right_op, right) {
+                acc.push(self.create_err(right));
+            }
+        }
+    }
+}
+impl Rule for SpTernaryRule {
+    fn name() -> &'static str {
+        "SP_TERNARY"
+    }
+    fn description() -> &'static str {
+        "Missing space around ? or : in conditional expression"
+    }
+    fn get_rule_type() -> RuleType {
+        RuleType::SpTernary
     }
 }
 

--- a/src/lint/rules/tests/spacing/mod.rs
+++ b/src/lint/rules/tests/spacing/mod.rs
@@ -1,6 +1,3 @@
-use crate::lint::rules::tests::common::assert_snippet;
-use crate::lint::rules::instantiate_rules;
-use crate::lint::LintCfg;
 mod nsp_funpar;
 mod nsp_inparen;
 mod nsp_ptrdecl;
@@ -25,15 +22,6 @@ if(this_some_integer == 0x666)
 }
 ";
 
-//  SP.ptrdecl between a type and the * marking a pointer
-#[allow(dead_code)]
-static SP_PTRDECL: &str = "
-method this_is_some_method(conf_object_t* dummy_obj) {
-if(!dummy_obj)
-    return;
-}
-";
-
 //  SP.comment around the comment delimiters //, /* and **/
 #[allow(dead_code)]
 static SP_COMMENT: &str = "
@@ -45,11 +33,3 @@ if(!dummy_obj)//Not null
 }
 ";
 
-//  NSP.ptrdecl after the * marking a pointer in a declaration
-#[allow(dead_code)]
-static NSP_PTRDECL: &str = "
-method this_is_some_method(conf_object_t * dummy_obj) {
-if(!dummy_obj)
-    return;
-}
-";

--- a/src/lint/rules/tests/spacing/mod.rs
+++ b/src/lint/rules/tests/spacing/mod.rs
@@ -4,6 +4,7 @@ mod nsp_trailing;
 mod nsp_unary;
 mod sp_braces;
 mod sp_punct;
+mod sp_binop;
 
 // Put whitespace (space or newline):
 //  SP.reserved around reserved words, such as if, else, default,
@@ -15,17 +16,6 @@ method this_is_some_method() {
 local int this_some_integer = 0x666;
 if(this_some_integer == 0x666)
     return;
-}
-";
-
-//  SP.binop around binary operators except the dereferencing operators dot
-//  (a.b) and arrow (a->b)
-#[allow(dead_code)]
-static SP_BINOP: &str = "
-method this_is_some_method() {
-local int this_some_integer = 5+6;
-if (this_some_integer == 0x666)
-    this_some_integer = this.val;
 }
 ";
 

--- a/src/lint/rules/tests/spacing/mod.rs
+++ b/src/lint/rules/tests/spacing/mod.rs
@@ -5,6 +5,7 @@ mod nsp_unary;
 mod sp_braces;
 mod sp_punct;
 mod sp_binop;
+mod sp_ternary;
 
 // Put whitespace (space or newline):
 //  SP.reserved around reserved words, such as if, else, default,
@@ -16,14 +17,6 @@ method this_is_some_method() {
 local int this_some_integer = 0x666;
 if(this_some_integer == 0x666)
     return;
-}
-";
-
-//  SP.ternary around ? and : in the ternary ?: operator
-#[allow(dead_code)]
-static SP_TERNARY: &str = "
-method this_is_some_method(bool flag) {
-local int this_some_integer = (flag?5:7));
 }
 ";
 

--- a/src/lint/rules/tests/spacing/sp_binop.rs
+++ b/src/lint/rules/tests/spacing/sp_binop.rs
@@ -3,8 +3,21 @@ use crate::lint::rules::RuleType;
 
 //  SP.binop around binary operators except the dereferencing operators dot
 //  (a.b) and arrow (a->b)
-#[allow(dead_code)]
-static SP_BINOP: &str = "
+static ARTITHMETIC_OPERATOR_CORRECT: &str = "
+method this_is_some_method() {
+    local int this_some_integer = 5 + 6;
+    if (this_some_integer == 0x666) {
+        this_some_integer = this.val;
+    }
+}
+";
+
+#[test]
+fn arithmetic_operator_correct() {
+	let rules = set_up();
+	assert_snippet(ARTITHMETIC_OPERATOR_CORRECT, vec![], &rules);
+}
+static ARTITHMETIC_OPERATOR_INCORRECT: &str = "
 method this_is_some_method() {
     local int this_some_integer = 5+6;
     if (this_some_integer == 0x666) {
@@ -21,8 +34,36 @@ fn arithmetic_operator_incorrect() {
 		(2, 2, 34, 35),
 		(2, 2, 36, 37),
 	);
-	assert_snippet(SP_BINOP, expected_errors, &rules);
+	assert_snippet(ARTITHMETIC_OPERATOR_INCORRECT, expected_errors, &rules);
 }
+
+static CONDITIONAL_OPERATOR_INCORRECT: &str = "
+method this_is_some_method() {
+    local int this_some_integer = 5 + 6;
+    if (this_some_integer==0x666) {
+        this_some_integer = this.val;
+    }
+}
+";
+#[test]
+fn conditional_operator_incorrect() {
+	let rules = set_up();
+    let expected_errors = define_expected_errors!(
+		RuleType::SpBinop,
+		(3, 3, 8, 25),
+		(3, 3, 27, 32),
+	);
+	assert_snippet(CONDITIONAL_OPERATOR_INCORRECT, expected_errors, &rules);
+}
+
+static SP_BINOP: &str = "
+method this_is_some_method() {
+    local int this_some_integer = 5+6;
+    if (this_some_integer == 0x666) {
+        this_some_integer = this.val;
+    }
+}
+";
 
 #[test]
 fn rule_disable() {

--- a/src/lint/rules/tests/spacing/sp_binop.rs
+++ b/src/lint/rules/tests/spacing/sp_binop.rs
@@ -1,0 +1,38 @@
+use crate::lint::rules::tests::common::{set_up, assert_snippet};
+use crate::lint::rules::RuleType;
+
+//  SP.binop around binary operators except the dereferencing operators dot
+//  (a.b) and arrow (a->b)
+#[allow(dead_code)]
+static SP_BINOP: &str = "
+method this_is_some_method() {
+    local int this_some_integer = 5+6;
+    if (this_some_integer == 0x666) {
+        this_some_integer = this.val;
+    }
+}
+";
+
+#[test]
+fn arithmetic_operator_incorrect() {
+	let rules = set_up();
+    let expected_errors = define_expected_errors!(
+		RuleType::SpBinop,
+		(2, 2, 34, 35),
+		(2, 2, 36, 37),
+	);
+	assert_snippet(SP_BINOP, expected_errors, &rules);
+}
+
+#[test]
+fn rule_disable() {
+	let mut rules = set_up();
+	let expected_errors = define_expected_errors!(
+		RuleType::SpBinop,
+		(2, 2, 34, 35),
+		(2, 2, 36, 37),
+	);
+	assert_snippet(SP_BINOP, expected_errors, &rules);
+	rules.sp_binop.enabled = false;
+	assert_snippet(SP_BINOP, vec![], &rules);
+}

--- a/src/lint/rules/tests/spacing/sp_ternary.rs
+++ b/src/lint/rules/tests/spacing/sp_ternary.rs
@@ -1,0 +1,76 @@
+use crate::lint::rules::tests::common::{set_up, assert_snippet};
+use crate::lint::rules::RuleType;
+
+
+//  SP.ternary around ? and : in the ternary ?: operator
+static VARIABLE_CONDITIONAL_CORRECT: &str = "
+method this_is_some_method(bool flag) {
+    local int this_some_integer = (flag ? 5 : 7);
+}
+";
+
+
+#[test]
+fn variable_conditional_correct() {
+	let rules = set_up();
+	assert_snippet(VARIABLE_CONDITIONAL_CORRECT, vec![], &rules);
+}
+
+static VARIABLE_CONDITIONAL_INCORRECT: &str = "
+method this_is_some_method(bool flag) {
+    local int this_some_integer = (flag?5:7);
+}
+";
+
+
+#[test]
+fn variable_conditional_incorrect() {
+	let rules = set_up();
+    let expected_errors = define_expected_errors!(
+		RuleType::SpTernary,
+		(2, 2, 35, 39),
+		(2, 2, 40, 41),
+		(2, 2, 40, 41),
+		(2, 2, 42, 43),
+	);
+	assert_snippet(VARIABLE_CONDITIONAL_INCORRECT, expected_errors, &rules);
+}
+
+static PARAM_CONDITIONAL_CORRECT: &str = "
+param even_or_odd = odd_flag ? 'odd' : 'even';
+";
+
+#[test]
+fn param_conditional_correct() {
+	let rules = set_up();
+	assert_snippet(PARAM_CONDITIONAL_CORRECT, vec![], &rules);
+}
+
+static PARAM_CONDITIONAL_INCORRECT: &str = "
+param even_or_odd = odd_flag ?'odd' :'even';
+";
+
+#[test]
+fn param_conditional_incorrect() {
+	let rules = set_up();
+	let expected_errors = define_expected_errors!(
+		RuleType::SpTernary,
+		(1, 1, 30, 35),
+		(1, 1, 37, 43),
+	);
+	assert_snippet(PARAM_CONDITIONAL_INCORRECT, expected_errors, &rules);
+}
+
+
+#[test]
+fn rule_disable() {
+	let mut rules = set_up();
+	let expected_errors = define_expected_errors!(
+		RuleType::SpTernary,
+		(1, 1, 30, 35),
+		(1, 1, 37, 43),
+	);
+	assert_snippet(PARAM_CONDITIONAL_INCORRECT, expected_errors, &rules);
+	rules.sp_ternary.enabled = false;
+	assert_snippet(PARAM_CONDITIONAL_INCORRECT, vec![], &rules);
+}


### PR DESCRIPTION
This pull request adds support for two new linting rules: `sp_binop` (spacing around binary operators) and `sp_ternary` (spacing in ternary conditional expressions). These changes include updates to the linting configuration, rule definitions, and corresponding test cases.

### New Linting Rules

#### Rule Definitions and Implementation:
* Added `SpBinopRule` and `SpTernaryRule` to enforce spacing around binary operators and ternary expressions, respectively. These include options, arguments, and logic to check for spacing violations. (`src/lint/rules/spacing.rs`)
* Integrated the new rules into the `CurrentRules` struct and the `instantiate_rules` function, enabling configuration-based activation. (`src/lint/rules/mod.rs`) [[1]](diffhunk://#diff-e62b9102bd89f96a0c706f7ec4e161f2c1a43af33a6286dcb086966e57db8719L7-R16) [[2]](diffhunk://#diff-e62b9102bd89f96a0c706f7ec4e161f2c1a43af33a6286dcb086966e57db8719R36-R37) [[3]](diffhunk://#diff-e62b9102bd89f96a0c706f7ec4e161f2c1a43af33a6286dcb086966e57db8719R74-R75)

#### Configuration and Defaults:
* Updated `LintCfg` to include `sp_binop` and `sp_ternary` as configurable options, with default values set in the `Default` implementation. (`src/lint/mod.rs`) [[1]](diffhunk://#diff-3e772988a916385076871a60f15b55f6b2df94f07853401f950e139b91f2daa7L5-R8) [[2]](diffhunk://#diff-3e772988a916385076871a60f15b55f6b2df94f07853401f950e139b91f2daa7R54-R57) [[3]](diffhunk://#diff-3e772988a916385076871a60f15b55f6b2df94f07853401f950e139b91f2daa7R92-R93)
* Modified the lint configuration file `example_lint_cfg.json` to support the new rules. (`example_files/example_lint_cfg.json`)

### Documentation
* Updated `features.md` to document the new rules, including descriptions and examples of their functionality. (`src/lint/features.md`)

### Testing
* Added test cases for `sp_binop` and `sp_ternary` rules, including positive and negative scenarios, as well as rule disablement tests. (`src/lint/rules/tests/spacing/sp_binop.rs`, `src/lint/rules/tests/spacing/sp_ternary.rs`) [[1]](diffhunk://#diff-959fa99d91863a8d5163f02a3d5fb3b40766b1b6188a1cdd38e3a77fd3c52c99R1-R79) [[2]](diffhunk://#diff-14a654050b683fdce659be779a080b566f2c897ba0f3895b90c04b83987755d1R1-R76)
* Removed outdated test cases related to binary and ternary operators from `spacing/mod.rs`. (`src/lint/rules/tests/spacing/mod.rs`) [[1]](diffhunk://#diff-13f558771d5b6fc24b8aa672a7d1ff7f256a5bc6581a27e504cb1860f75a8ab2R12-R13) [[2]](diffhunk://#diff-13f558771d5b6fc24b8aa672a7d1ff7f256a5bc6581a27e504cb1860f75a8ab2L26-L44)